### PR TITLE
feat: add arm64 Linux target

### DIFF
--- a/dist/binary/binaryUtils.js
+++ b/dist/binary/binaryUtils.js
@@ -7,14 +7,20 @@ const DEFAULT_NEAR_SANDBOX_VERSION = "2.6.5";
 function getPlatform() {
     const type = os.type();
     const arch = os.arch();
-    // Darwind x86_64 is not supported for quite some time :(
     if (type === "Linux" && arch === "x64") {
-        return [type, "x86_64"];
+        return ["Linux", "x86_64"];
     }
-    else if (type === "Darwin" && arch === "arm64") {
-        return [type, "arm64"];
+    if (type === "Linux" && arch === "arm64") {
+        return ["Linux", "aarch64"];
     }
-    throw new Error("Only linux-x86 and darwin-arm are supported");
+    // Darwind x86_64 is not supported for quite some time :(
+    if (type === "Darwin" && arch === "x64") {
+        throw new Error("Darwin x86_64 is not supported");
+    }
+    if (type === "Darwin" && arch === "arm64") {
+        return ["Darwin", "arm64"];
+    }
+    throw new Error(`Unsupported platform: ${type}-${arch}`);
 }
 function AWSUrl(version = DEFAULT_NEAR_SANDBOX_VERSION) {
     const [platform, arch] = getPlatform();

--- a/src/binary/binaryUtils.ts
+++ b/src/binary/binaryUtils.ts
@@ -4,19 +4,23 @@ import * as os from "os";
 const DEFAULT_NEAR_SANDBOX_VERSION = "2.6.5";
 
 function getPlatform() {
-  const type = os.type();
-  const arch = os.arch();
-
-  // Darwind x86_64 is not supported for quite some time :(
-  if (type === "Linux" && arch === "x64") {
-    return [type, "x86_64"];
-  } else if (type === "Darwin" && arch === "arm64") {
-    return [type, "arm64"];
-  }
-
-  throw new Error("Only linux-x86 and darwin-arm are supported");
+    const type = os.type();  
+    const arch = os.arch();
+    if (type === "Linux" && arch === "x64") {
+        return ["Linux", "x86_64"];
+    }
+    if (type === "Linux" && arch === "arm64") {
+        return ["Linux", "aarch64"];
+    }
+    // Darwind x86_64 is not supported for quite some time :(
+    if (type === "Darwin" && arch === "x64") {
+        throw new Error("Darwin x86_64 is not supported");
+    }
+    if (type === "Darwin" && arch === "arm64") {
+        return ["Darwin", "arm64"];
+    }
+    throw new Error(`Unsupported platform: ${type}-${arch}`);
 }
-
 export function AWSUrl(version: string = DEFAULT_NEAR_SANDBOX_VERSION): string {
   const [platform, arch] = getPlatform();
   return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/${version}/near-sandbox.tar.gz`;


### PR DESCRIPTION
Related Issue:
https://github.com/near/near-workspaces-rs/issues/429

I added the new target and tested it — everything runs well on ARM64 Linux. However, I noticed an interesting detail that is not mentioned in the README. Before I was able to run `cargo test` and execute the examples, I had to apply the following settings:

```bash
sudo sysctl -w net.core.rmem_max=8388608
sudo sysctl -w net.core.wmem_max=8388608
sudo sysctl -w "net.ipv4.tcp_rmem=4096 87380 8388608"
sudo sysctl -w "net.ipv4.tcp_wmem=4096 16384 8388608"
sudo sysctl -w net.ipv4.tcp_slow_start_after_idle=0
```

Without these parameters, I was getting errors when running both the tests and the examples.

I also noticed an interesting pattern: in a seemingly random manner, there is about a 50/50 chance that all tests pass successfully or that some of them fail. I included screenshots showing this behavior in the pull request.
![5285482837630980283](https://github.com/user-attachments/assets/09f62626-0792-454e-9ccf-2d2caed0e3ce)
![5285482837630980288](https://github.com/user-attachments/assets/83dd6899-2463-48e2-be77-8c26f8bf274d)
