### PR TITLE
fix: update nearcore to 2.13.1 and fix version-check regex

### DIFF
--- a/.changeset/update-nearcore-2-13-1.md
+++ b/.changeset/update-nearcore-2-13-1.md
@@ -1,0 +1,5 @@
+---
+"near-sandbox": patch
+---
+
+Update nearcore version to 2.13.1

--- a/scripts/check-nearcore-release.js
+++ b/scripts/check-nearcore-release.js
@@ -31,7 +31,7 @@ function getCurrentVersion() {
   try {
     const constantsTsPath = path.join(process.cwd(), CONSTANTS_TS_PATH);
     const content = fs.readFileSync(constantsTsPath, 'utf8');
-    const match = content.match(/DEFAULT_NEAR_SANDBOX_VERSION = "([^"]+)"/);
+    const match = content.match(/DEFAULT_NEAR_SANDBOX_VERSION = ['"]([^'"]+)['"]/);
 
     if (!match) {
       throw new Error('Could not find DEFAULT_NEAR_SANDBOX_VERSION in constants.ts');
@@ -52,8 +52,8 @@ function updateConstantsTs(newVersion) {
     let content = fs.readFileSync(constantsPath, 'utf8');
 
     content = content.replace(
-      /DEFAULT_NEAR_SANDBOX_VERSION = "[^"]+"/,
-      `DEFAULT_NEAR_SANDBOX_VERSION = "${newVersion}"`,
+      /DEFAULT_NEAR_SANDBOX_VERSION = ['"][^'"]+['"]/,
+      `DEFAULT_NEAR_SANDBOX_VERSION = '${newVersion}'`,
     );
 
     fs.writeFileSync(constantsPath, content, 'utf8');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
 /**
  * Default version of NEAR Sandbox binary to download and use
  */
-export const DEFAULT_NEAR_SANDBOX_VERSION = '2.11.1';
+export const DEFAULT_NEAR_SANDBOX_VERSION = '2.13.1';


### PR DESCRIPTION
## Motivation

The nearcore auto-update workflow has been failing since the Biome reformat (#46) switched `constants.ts` to single quotes — the update script's regex only matched double quotes, so no bump PRs were created after 2.11.1. GitHub then auto-disabled the schedule (`disabled_inactivity`).

## Changes

- Bump `DEFAULT_NEAR_SANDBOX_VERSION` to 2.13.1 (latest stable)
- Fix the script regex to accept either quote style
- Changeset included

## Test Plan

- Full test suite passes against the 2.13.1 binary (12/12)
- `node scripts/check-nearcore-release.js` now parses the single-quoted constant correctly

The workflow schedule has been re-enabled separately.