### PR TITLE
fix: poll sandbox RPC with fetch instead of got

### DIFF
--- a/.changeset/tidy-pugs-invite.md
+++ b/.changeset/tidy-pugs-invite.md
@@ -1,0 +1,5 @@
+---
+"near-sandbox": patch
+---
+
+Poll the sandbox RPC with `fetch` instead of `got`, fixing startup on Node >= 26.7 where a refused connection crashed the process with an uncaught error.

--- a/__tests__/sandbox.ava.ts
+++ b/__tests__/sandbox.ava.ts
@@ -61,6 +61,7 @@ test('Sandbox.tearDown() cleans up resources and unlocks ports', async (t) => {
 
   // Verify sandbox is running by checking the RPC endpoint
   const status = await fetch(`${sandbox.rpcUrl}/status`);
+  await status.body?.cancel();
   t.true(status.ok);
 
   // Now try to bind to the same port - should fail since sandbox is using it

--- a/__tests__/sandbox.ava.ts
+++ b/__tests__/sandbox.ava.ts
@@ -1,7 +1,6 @@
 import { KeyPair } from '@near-js/crypto';
 import test from 'ava';
 import { existsSync } from 'fs';
-import got from 'got';
 import * as net from 'net';
 import { join } from 'path';
 import { GenesisAccount, Sandbox, type SandboxConfig } from '../src';
@@ -61,7 +60,8 @@ test('Sandbox.tearDown() cleans up resources and unlocks ports', async (t) => {
   t.true(dirExistsBefore);
 
   // Verify sandbox is running by checking the RPC endpoint
-  await got(`${sandbox.rpcUrl}/status`);
+  const status = await fetch(`${sandbox.rpcUrl}/status`);
+  t.true(status.ok);
 
   // Now try to bind to the same port - should fail since sandbox is using it
   await t.throwsAsync(
@@ -98,9 +98,10 @@ test('Sandbox.rpcUrl is not reachable after stoppage', async (t) => {
   const rpcUrl = sandbox.rpcUrl;
 
   await sandbox.stop();
-  await t.throwsAsync(() => got(rpcUrl + '/status', { throwHttpErrors: false }), {
-    message: /ECONNREFUSED/,
-  });
+  const error = (await t.throwsAsync(() =>
+    fetch(`${rpcUrl}/status`, { signal: AbortSignal.timeout(5000) }),
+  )) as (Error & { cause?: NodeJS.ErrnoException }) | undefined;
+  t.is(error?.cause?.code, 'ECONNREFUSED');
 });
 test('Sandbox throws if provided rpcPort is already in use', async (t) => {
   const rpcPort = 3050;

--- a/src/sandbox/Sandbox.ts
+++ b/src/sandbox/Sandbox.ts
@@ -157,16 +157,20 @@ export class Sandbox {
 
   private static async waitUntilReady(rpcUrl: string) {
     const timeoutSecs = parseInt(process.env['NEAR_RPC_TIMEOUT_SECS'] || '10');
-    const attempts = timeoutSecs * 2;
+    const deadline = Date.now() + timeoutSecs * 1000;
     let lastError: unknown = null;
-    for (let i = 0; i < attempts; i++) {
+    // A hanging request must not push the total wait past NEAR_RPC_TIMEOUT_SECS,
+    // so each attempt is bounded by whatever is left of the deadline.
+    for (let remaining = timeoutSecs * 1000; remaining > 0; remaining = deadline - Date.now()) {
       try {
         // Polled with `fetch` rather than `got`: on Node >= 26.7 a refused
         // connection makes got@11 raise "The `onCancel` handler was attached
         // after the promise settled" as an uncaught exception, which no
         // try/catch here can contain. The sandbox always refuses the first few
         // polls while it boots, so that crashed every run.
-        const response = await fetch(`${rpcUrl}/status`, { signal: AbortSignal.timeout(5000) });
+        const response = await fetch(`${rpcUrl}/status`, {
+          signal: AbortSignal.timeout(remaining),
+        });
         await response.body?.cancel();
         if (response.ok) {
           return;

--- a/src/sandbox/Sandbox.ts
+++ b/src/sandbox/Sandbox.ts
@@ -1,6 +1,5 @@
 import { ChildProcess } from 'child_process';
 import { rm } from 'fs/promises';
-import got from 'got';
 import { unlock } from 'proper-lockfile';
 import { DirectoryResult } from 'tmp-promise';
 import { initConfigsWithVersion, spawnWithArgsAndVersion } from '../binary/binaryExecution';
@@ -162,8 +161,14 @@ export class Sandbox {
     let lastError: unknown = null;
     for (let i = 0; i < attempts; i++) {
       try {
-        const response = await got(`${rpcUrl}/status`, { throwHttpErrors: false });
-        if (response.statusCode >= 200 && response.statusCode < 300) {
+        // Polled with `fetch` rather than `got`: on Node >= 26.7 a refused
+        // connection makes got@11 raise "The `onCancel` handler was attached
+        // after the promise settled" as an uncaught exception, which no
+        // try/catch here can contain. The sandbox always refuses the first few
+        // polls while it boots, so that crashed every run.
+        const response = await fetch(`${rpcUrl}/status`, { signal: AbortSignal.timeout(5000) });
+        await response.body?.cancel();
+        if (response.ok) {
           return;
         }
       } catch (error) {


### PR DESCRIPTION
## Cause

`Sandbox.waitUntilReady` polls `${rpcUrl}/status` with `got@11`. On Node >= 26.7 a refused connection makes got raise `The \`onCancel\` handler was attached after the promise settled` as an **uncaught** exception, so the surrounding try/catch cannot contain it. The sandbox always refuses the first few polls while neard boots, so every test that starts a sandbox kills its AVA worker.

CI's `node-version: latest` leg moved from Node 26.5.1 to 26.7.0 between Jul 29 and Aug 6, which is when the suite went red. This is on `main`, not in the 2.13.3 bump — `main` at 2.13.2 fails identically under Node 26.7.0, and the 2.13.3 Linux/Darwin artifacts are healthy.

## Fix

Poll with Node's built-in `fetch`, which reports the refusal as a catchable `ECONNREFUSED` on both Node 24 and 26.7. Same change in `__tests__/sandbox.ava.ts`, whose 'not reachable after stoppage' test hit the identical crash asserting on got's error.

## Repro

Verified locally on Linux against both Node versions:

| | 2.13.2 (main) | with this fix |
|---|---|---|
| Node 24.1.0 | 12 passed | 12 passed |
| Node 26.7.0 | 1 passed, 5 uncaught exceptions | 12 passed |

Unblocks #56.